### PR TITLE
throw an error on suspicious comments

### DIFF
--- a/src/default-matcher.js
+++ b/src/default-matcher.js
@@ -23,6 +23,9 @@ let validTypes = new Set(Object.keys(Shift));
 module.exports = function defaultMatcher(text) {
   let match = text.match(/^# ([^#]+) (?:# ([^#]+) )?#$/);
   if (match === null) {
+    if (text.match(/(^\s*#)|(#\s*$)/)) {
+      throw new Error('This comment looks kind of like a template comment, but not precisely; this is probably a bug.');
+    }
     return null;
   }
   if (typeof match[2] === 'string') {

--- a/test/apply-template.js
+++ b/test/apply-template.js
@@ -97,4 +97,9 @@ describe('applyTemplate failure cases', () => {
       one: () => new Shift.LiteralNullExpression,
     });
   });
+
+  it('suspicious comment', () => {
+    const source = 'a + /*# label # */ b';
+    fails(source, {});
+  });
 });


### PR DESCRIPTION
on top of #17.

Fixes #6, except I just made it throw; there's no good way to just warn. If you want to suppress this error you can provide a custom matcher.