### PR TITLE
Release 3.0.0

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -31,16 +31,16 @@ jobs:
 
     strategy:
       matrix:
-        node: [14, 16, 18]
+        node: [20, 24]
 
     name: Check - node ${{ matrix.node }}
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,26 @@
+name: publish
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Publish
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN_FOR_SHAPESECURITY_USER }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "shift-template",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "shift-template",
-      "version": "2.0.0",
+      "version": "3.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "shift-ast": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shift-template",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "Shift format AST-based template system for JavaScript",
   "author": "Shape Security",
   "homepage": "https://github.com/shapesecurity/shift-template-js",

--- a/src/default-matcher.js
+++ b/src/default-matcher.js
@@ -24,7 +24,7 @@ module.exports = function defaultMatcher(text) {
   let match = text.match(/^# ([^#]+) (?:# ([^#]+) )?#$/);
   if (match === null) {
     if (text.match(/(^\s*#)|(#\s*$)/)) {
-      throw new Error('This comment looks kind of like a template comment, but not precisely; this is probably a bug.');
+      throw new Error(`This comment looks kind of like a template comment, but not precisely; this is probably a bug: ${JSON.stringify(text)}`);
     }
     return null;
   }


### PR DESCRIPTION
Major due to inclusion of https://github.com/shapesecurity/shift-template-js/commit/f4fbe092d5da5d40dc867884faf051b0626d417e, which we apparently never released. I only actually care about https://github.com/shapesecurity/shift-template-js/pull/18 though.